### PR TITLE
Add web server dashboard integration

### DIFF
--- a/WEB_STATIC/app.js
+++ b/WEB_STATIC/app.js
@@ -1,0 +1,56 @@
+async function fetchState() {
+  try {
+    const res = await fetch('/api/state');
+    const data = await res.json();
+    updateDistance(data.distance);
+    updateApiLog(data.api_log);
+    updateSchedule(data.schedule);
+    updateServerLog(data.logs);
+  } catch (e) {
+    console.error('State fetch error', e);
+  }
+}
+
+function updateDistance(d) {
+  if (!d) return;
+  const el = document.getElementById('distance-value');
+  el.textContent = d.current_distance.toFixed(2) + 'px';
+}
+
+function updateApiLog(list) {
+  const ul = document.getElementById('api-log');
+  ul.innerHTML = '';
+  list.slice().reverse().forEach(item => {
+    const li = document.createElement('li');
+    li.textContent = `/api/${item.endpoint} - ${item.status}`;
+    ul.appendChild(li);
+  });
+}
+
+function updateSchedule(list) {
+  const ul = document.getElementById('schedule-list');
+  ul.innerHTML = '';
+  list.forEach(item => {
+    const li = document.createElement('li');
+    if (typeof item === 'string') {
+      li.textContent = item;
+    } else {
+      li.textContent = `${item.이름 || item.name} - ${item.시간 || ''}`;
+    }
+    ul.appendChild(li);
+  });
+}
+
+function updateServerLog(list) {
+  const ul = document.getElementById('log-list');
+  ul.innerHTML = '';
+  list.slice().reverse().forEach(msg => {
+    const li = document.createElement('li');
+    li.textContent = msg;
+    ul.appendChild(li);
+  });
+}
+
+fetchState();
+setInterval(fetchState, 2000);
+

--- a/WEB_STATIC/index.html
+++ b/WEB_STATIC/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>IoT 모니터링 대시보드</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>IoT 모니터링 대시보드</h1>
+            <p>실시간 센서 데이터 및 시스템 상태 모니터링</p>
+        </header>
+        <section class="row">
+            <div class="card" id="distance-card">
+                <h2>거리 센서 모니터링</h2>
+                <div id="distance-value">--</div>
+                <div class="chart-placeholder">차트 영역</div>
+            </div>
+            <div class="card" id="api-card">
+                <h2>API 호출 통계</h2>
+                <ul id="api-log"></ul>
+                <div class="chart-placeholder">차트 영역</div>
+            </div>
+        </section>
+        <section class="row">
+            <div class="card" id="schedule-card">
+                <h2>일정 관리</h2>
+                <ul id="schedule-list"></ul>
+            </div>
+            <div class="card" id="log-card">
+                <h2>서버 로그</h2>
+                <ul id="log-list"></ul>
+            </div>
+        </section>
+    </div>
+<script src="app.js"></script>
+</body>
+</html>

--- a/WEB_STATIC/styles.css
+++ b/WEB_STATIC/styles.css
@@ -1,0 +1,54 @@
+body {
+    margin: 0;
+    font-family: sans-serif;
+    background: linear-gradient(45deg, #f5f5f5, #e0e0e0);
+    color: #333;
+}
+.container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 20px;
+}
+header {
+    text-align: center;
+    margin-bottom: 20px;
+}
+header h1 {
+    margin: 0;
+    font-size: 2.5rem;
+}
+.row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+    margin-bottom: 20px;
+}
+.card {
+    background: #fff;
+    padding: 20px;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    flex: 1 1 calc(50% - 20px);
+}
+.card h2 {
+    margin-top: 0;
+    font-size: 1.2rem;
+}
+.chart-placeholder {
+    height: 150px;
+    background: #f0f0f0;
+    border: 1px dashed #ccc;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #999;
+    margin-top: 10px;
+}
+ul {
+    list-style: none;
+    padding: 0;
+}
+li {
+    padding: 4px 0;
+    border-bottom: 1px solid #eee;
+}

--- a/web_server.py
+++ b/web_server.py
@@ -1,17 +1,66 @@
-from flask import Flask, request, jsonify
+from flask import Flask, request, jsonify, send_from_directory
 import time
+import os
 
-app = Flask(__name__)
+app = Flask(__name__, static_folder='WEB_STATIC', static_url_path='')
+
+# 최근 데이터 저장용 간단한 메모리 버퍼
+distance_state = {}
+api_log = []
+schedule_list = []
+server_log = []
+
+def log_api(endpoint, status=200):
+    """API 호출 내역 기록"""
+    api_log.append({'endpoint': endpoint, 'status': status, 'timestamp': time.time()})
+    if len(api_log) > 20:
+        del api_log[0]
+
+
+@app.route('/api/state', methods=['GET'])
+def state():
+    """현재 저장된 데이터 반환"""
+    return jsonify({
+        'distance': distance_state,
+        'api_log': api_log,
+        'schedule': schedule_list,
+        'logs': server_log
+    })
+
+
+@app.route('/')
+def root():
+    """정적 대시보드 제공"""
+    return send_from_directory(app.static_folder, 'index.html')
 
 @app.route('/api/distance', methods=['POST'])
 def receive_distance():
     data = request.get_json()
+    distance_state.update({
+        'current_distance': data.get('current_distance'),
+        'initial_distance': data.get('initial_distance'),
+        'distance_difference': data.get('distance_difference'),
+        'elapsed_time': data.get('elapsed_time'),
+        'source': data.get('source'),
+        'timestamp': time.time()
+    })
+
+    log_api('distance')
+    msg = (
+        f"{distance_state.get('current_distance'):.2f}px "
+        f"(Δ{distance_state.get('distance_difference'):.2f}px)"
+    )
+    server_log.append(f"distance: {msg}")
+    if len(server_log) > 50:
+        del server_log[0]
+
     print("📏 [웹서버] 거리 측정 결과 수신:")
-    print(f" - 현재 거리: {data.get('current_distance'):.2f}px")
-    print(f" - 초기 거리: {data.get('initial_distance'):.2f}px")
-    print(f" - 차이: {data.get('distance_difference'):.2f}px")
-    print(f" - 경과 시간: {data.get('elapsed_time'):.2f}s")
-    print(f" - 출처: {data.get('source')}")
+    print(f" - 현재 거리: {distance_state.get('current_distance'):.2f}px")
+    print(f" - 초기 거리: {distance_state.get('initial_distance'):.2f}px")
+    print(f" - 차이: {distance_state.get('distance_difference'):.2f}px")
+    print(f" - 경과 시간: {distance_state.get('elapsed_time'):.2f}s")
+    print(f" - 출처: {distance_state.get('source')}")
+
     return jsonify({"status": "ok", "message": "Distance received"}), 200
 
 @app.route('/api/voice-result', methods=['POST'])
@@ -22,20 +71,31 @@ def receive_voice_result():
     if data_type == "add":
         print("[웹서버] 일정 추가 수신:")
         print(data.get("data"))
+        schedule_list.append(data.get("data"))
+        server_log.append("schedule added")
 
     elif data_type == "view":
         print("[웹서버] 일정 조회 결과 수신:")
         for entry in data.get("data", []):
             print(entry)
+        schedule_list[:] = data.get("data", [])
+        server_log.append("schedule view")
 
     elif data_type == "exit":
         print("[웹서버] 종료 명령 수신:")
         print(data.get("message"))
+        server_log.append("exit")
 
     else:
         print("[웹서버] 알 수 없는 타입의 데이터 수신:", data)
+        server_log.append("unknown data")
+
+    log_api('voice-result')
+    if len(server_log) > 50:
+        del server_log[0]
 
     return jsonify({"status": "ok", "message": "Voice result received"}), 200
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=3000, debug=True)
+


### PR DESCRIPTION
## Summary
- expose `/` and `/api/state` from `web_server.py` to serve the HTML dashboard and share recent data
- keep the latest distance and voice results in memory and record API calls
- rework `WEB_STATIC/app.js` to poll `/api/state` and update the page

## Testing
- `python3 -m py_compile web_server.py`
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68430e7ba7d08324927c53f3c148cdbb